### PR TITLE
More fluid scrolling

### DIFF
--- a/Classes/PXListView.m
+++ b/Classes/PXListView.m
@@ -272,8 +272,15 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	if([delegate conformsToProtocol: @protocol(PXListViewDelegate)])
 	{
 		NSRange visibleRange = [self visibleRange];
+		//extend to adjacent rows for offscreen preparation
+		NSUInteger startRow = visibleRange.location;
+		if (startRow > 0)
+			startRow--;
+		NSUInteger endRow = NSMaxRange(visibleRange);
+		if(endRow < [delegate numberOfRowsInListView:self])
+			endRow++;
 		
-		for(NSUInteger i = visibleRange.location; i < NSMaxRange(visibleRange); i++)
+		for(NSUInteger i = startRow; i < endRow; i++)
 		{
 			id cell = nil;
             cell = [delegate listView: self cellForRow: i];


### PR DESCRIPTION
This change was tested with ViennaRSS whose cells include Webviews : scrolling appears to be more fluid, and there are less visual artifacts when a view is slow to load.

We don't strictly limit the PXListView to the visible cells, but prepare the adjacent cells too.
