### PR TITLE
More fluid scrolling, continued. (replaces pull request #27 and #28)

### DIFF
--- a/Classes/PXListView+Private.h
+++ b/Classes/PXListView+Private.h
@@ -26,7 +26,7 @@ typedef NSInteger PXIsDragStartResult;
 - (void)layoutCells;
 - (void)layoutCell:(PXListViewCell*)cell atRow:(NSUInteger)row;
 
-- (void)addCellsFromVisibleRange;
+- (void)addCellsFromExtendedRange;
 - (PXListViewCell*)visibleCellForRow:(NSUInteger)row;
 - (NSArray*)visibleCellsForRowIndexes:(NSIndexSet*)rows;
 

--- a/Classes/PXListView+UserInteraction.m
+++ b/Classes/PXListView+UserInteraction.m
@@ -278,7 +278,7 @@ static PXIsDragStartResult PXIsDragStart( NSEvent *startEvent, NSTimeInterval th
 	
 	// Determine how large an image we'll need to hold all cells, with their
 	//	*unclipped* rectangles:
-	for( PXListViewCell* currCell in _visibleCells )
+	for( PXListViewCell* currCell in _cellsInViewHierarchy )
 	{
 		NSUInteger		currRow = [currCell row];
 		if( [dragRows containsIndex: currRow] )
@@ -301,7 +301,7 @@ static PXIsDragStartResult PXIsDragStart( NSEvent *startEvent, NSTimeInterval th
 	
 	[dragImage lockFocus];
     
-    for( PXListViewCell* currCell in _visibleCells )
+    for( PXListViewCell* currCell in _cellsInViewHierarchy )
     {
         NSUInteger		currRow = [currCell row];
         if( [dragRows containsIndex: currRow] )

--- a/Classes/PXListView.h
+++ b/Classes/PXListView.h
@@ -22,7 +22,7 @@
 	id <PXListViewDelegate> _delegate;
 	
 	NSMutableArray *_reusableCells;
-	NSMutableArray *_visibleCells;
+	NSMutableArray *_cellsInViewHierarchy;
 	NSRange _currentRange;
 	
 	NSUInteger _numberOfRows;

--- a/Classes/PXListView.m
+++ b/Classes/PXListView.m
@@ -32,7 +32,7 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	if((self = [super initWithFrame:theFrame]))
 	{
 		_reusableCells = [[NSMutableArray alloc] init];
-		_visibleCells = [[NSMutableArray alloc] init];
+		_cellsInViewHierarchy = [[NSMutableArray alloc] init];
 		_selectedRows = [[NSMutableIndexSet alloc] init];
 		_allowsEmptySelection = YES;
         _usesLiveResize = YES;
@@ -46,7 +46,7 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	if((self = [super initWithCoder:decoder]))
 	{
 		_reusableCells = [[NSMutableArray alloc] init];
-		_visibleCells = [[NSMutableArray alloc] init];
+		_cellsInViewHierarchy = [[NSMutableArray alloc] init];
 		_selectedRows = [[NSMutableIndexSet alloc] init];
 		_allowsEmptySelection = YES;
         _usesLiveResize = YES;
@@ -76,7 +76,7 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	
 	[_reusableCells release], _reusableCells = nil;
-	[_visibleCells release], _visibleCells = nil;
+	[_cellsInViewHierarchy release], _cellsInViewHierarchy = nil;
 	[_selectedRows release], _selectedRows = nil;
 	
 	[super dealloc];
@@ -117,16 +117,16 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 {
 	id <PXListViewDelegate> delegate = [self delegate];
 	
-	// Move all visible cells to the reusable cells array
-	NSUInteger numCells = [_visibleCells count];
+	// Move all managed cells to the reusable cells array
+	NSUInteger numCells = [_cellsInViewHierarchy count];
 	for (NSUInteger i = 0; i < numCells; i++)
 	{
-		PXListViewCell *cell = [_visibleCells objectAtIndex:i];
+		PXListViewCell *cell = [_cellsInViewHierarchy objectAtIndex:i];
 		[_reusableCells addObject:cell];
 		[cell setHidden:YES];
 	}
 	
-	[_visibleCells removeAllObjects];
+	[_cellsInViewHierarchy removeAllObjects];
 	free(_cellYOffsets);
 	
 	[_selectedRows removeAllIndexes];
@@ -137,9 +137,9 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 		_numberOfRows = [delegate numberOfRowsInListView:self];
 		[self cacheCellLayout];
 		
-		NSRange visibleRange = [self visibleRange];
-		_currentRange = visibleRange;
-		[self addCellsFromVisibleRange];
+		NSRange extendedRange = [self extendedRange];
+		_currentRange = extendedRange;
+		[self addCellsFromExtendedRange];
 		
 		[self layoutCells];
 	}
@@ -158,7 +158,7 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	if (cell != nil)
 	{
 		[_reusableCells addObject:cell];
-		[_visibleCells removeObject:cell];
+		[_cellsInViewHierarchy removeObject:cell];
 		[cell setHidden:YES];
 	}
 }
@@ -191,7 +191,18 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 
 - (NSArray*)visibleCells
 {
-    return [[_visibleCells copy] autorelease];
+	NSRange visibleRange = [self visibleRange];
+	NSUInteger firstIndex;
+	for(PXListViewCell *cell in _cellsInViewHierarchy)
+	{
+		NSUInteger row = [cell row];
+		if ( row >= visibleRange.location)
+		{
+			firstIndex =  [_cellsInViewHierarchy indexOfObject:cell];
+			break;
+		}
+	}
+    return [_cellsInViewHierarchy subarrayWithRange:NSMakeRange(firstIndex, visibleRange.length)];
 }
 
 - (NSRange)visibleRange
@@ -204,6 +215,49 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	for(NSUInteger i = 0; i < _numberOfRows; i++)
 	{
 		if(NSIntersectsRect([self rectOfRow:i], visibleRect))
+		{
+			if(startRow == NSUIntegerMax)
+			{
+				startRow = i;
+				inRange = YES;
+			}
+		}
+		else
+		{
+			if(inRange)
+			{
+				endRow = i;
+				break;
+			}
+		}
+	}
+
+	if(endRow == NSUIntegerMax)
+	{
+		endRow = _numberOfRows;
+	}
+
+	return NSMakeRange(startRow, endRow-startRow);
+}
+
+/* extendedRange
+ * Range of rows we need to keep in the cell view hierarchy
+ * we include the visible rows, plus those needed to be able to respond quickly
+ * to pageDown and pageUp requests
+ */
+- (NSRange)extendedRange
+{
+	NSRect visibleRect = [[self contentView] documentVisibleRect];
+	//extend to adjacent rows for offscreen preparation
+	NSRect extendedRect = NSMakeRect( visibleRect.origin.x, visibleRect.origin.y - visibleRect.size.height,
+		visibleRect.size.width, 3 * visibleRect.size.height);
+	NSUInteger startRow = NSUIntegerMax;
+	NSUInteger endRow = NSUIntegerMax;
+
+	BOOL inRange = NO;
+	for(NSUInteger i = 0; i < _numberOfRows; i++)
+	{
+		if(NSIntersectsRect([self rectOfRow:i], extendedRect))
 		{
 			if(startRow == NSUIntegerMax)
 			{
@@ -233,7 +287,10 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 {
 	PXListViewCell *outCell = nil;
 	
-	for(PXListViewCell *cell in _visibleCells)
+	NSRange visibleRange = [self visibleRange];
+	if ( row < visibleRange.location || row >= NSMaxRange(visibleRange) )
+		return nil;
+	for(PXListViewCell *cell in _cellsInViewHierarchy)
 	{
 		if([cell row] == row)
 		{
@@ -247,16 +304,28 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 
 -(PXListViewCell *)cellForRowAtIndex:(NSUInteger)inIndex
 {
-    return [self visibleCellForRow:inIndex];
+	PXListViewCell *outCell = nil;
+	for(PXListViewCell *cell in _cellsInViewHierarchy)
+	{
+		if([cell row] == inIndex)
+		{
+			outCell = cell;
+			break;
+		}
+	}
+
+	return outCell;
 }
 
 - (NSArray*)visibleCellsForRowIndexes:(NSIndexSet*)rows
 {
 	NSMutableArray *theCells = [NSMutableArray array];
+	NSRange visibleRange = [self visibleRange];
 	
-	for(PXListViewCell *cell in _visibleCells)
+	for(PXListViewCell *cell in _cellsInViewHierarchy)
 	{
-		if([rows containsIndex:[cell row]])
+		NSUInteger row = [cell row];
+		if ( row >= visibleRange.location && row < NSMaxRange(visibleRange) && [rows containsIndex:row] )
 		{
 			[theCells addObject:cell];
 		}
@@ -265,26 +334,19 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	return theCells;
 }
 
-- (void)addCellsFromVisibleRange
+- (void)addCellsFromExtendedRange
 {
 	id<PXListViewDelegate>	delegate = [self delegate];
-	
+
 	if([delegate conformsToProtocol: @protocol(PXListViewDelegate)])
 	{
-		NSRange visibleRange = [self visibleRange];
-		//extend to adjacent rows for offscreen preparation
-		NSUInteger startRow = visibleRange.location;
-		if (startRow > 0)
-			startRow--;
-		NSUInteger endRow = NSMaxRange(visibleRange);
-		if(endRow < [delegate numberOfRowsInListView:self])
-			endRow++;
-		
-		for(NSUInteger i = startRow; i < endRow; i++)
+		NSRange extendedRange = [self extendedRange];
+
+		for(NSUInteger i = extendedRange.location; i < NSMaxRange(extendedRange); i++)
 		{
 			id cell = nil;
             cell = [delegate listView: self cellForRow: i];
-			[_visibleCells addObject:cell];
+			[_cellsInViewHierarchy addObject:cell];
 			
 			[self layoutCell:cell atRow:i];
 		}
@@ -293,67 +355,67 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 
 - (void)updateCells
 {	
-	NSRange visibleRange = [self visibleRange];
-	NSRange intersectionRange = NSIntersectionRange(visibleRange, _currentRange);
+	NSRange extendedRange = [self extendedRange];
+	NSRange intersectionRange = NSIntersectionRange(extendedRange, _currentRange);
 	
 	//Have the cells we need to display actually changed?
-	if((visibleRange.location == _currentRange.location) && (NSMaxRange(visibleRange) == NSMaxRange(_currentRange))) {
+	if((extendedRange.location == _currentRange.location) && (NSMaxRange(extendedRange) == NSMaxRange(_currentRange))) {
 		return;
 	}
 	
 	if((intersectionRange.location == 0) && (intersectionRange.length == 0))
 	{
 		// We'll have to rebuild all the cells:
-		[_reusableCells addObjectsFromArray:_visibleCells];
-		[_visibleCells removeAllObjects];
+		[_reusableCells addObjectsFromArray:_cellsInViewHierarchy];
+		[_cellsInViewHierarchy removeAllObjects];
 		[[self documentView] setSubviews:[NSArray array]];
-		[self addCellsFromVisibleRange];
+		[self addCellsFromExtendedRange];
 	}
 	else
 	{
-		if(visibleRange.location < _currentRange.location) // Add top. 
+		if(extendedRange.location < _currentRange.location) // Add top.
 		{
-			for( NSUInteger i = _currentRange.location; i > visibleRange.location; i-- )
+			for( NSUInteger i = _currentRange.location; i > extendedRange.location; i-- )
 			{
 				NSUInteger newRow = i -1;
 				PXListViewCell *cell = [[self delegate] listView:self cellForRow:newRow];
                 
-				[_visibleCells insertObject: cell atIndex:0];
+				[_cellsInViewHierarchy insertObject: cell atIndex:0];
 				[self layoutCell:cell atRow:newRow];
 			}
 		}
         
-		if(visibleRange.location > _currentRange.location) // Remove top.
+		if(extendedRange.location > _currentRange.location) // Remove top.
 		{
-			for(NSUInteger i = visibleRange.location; i > _currentRange.location; i--)
+			for(NSUInteger i = extendedRange.location; i > _currentRange.location; i--)
 			{
-				if ([_visibleCells count])
-					[self enqueueCell:[_visibleCells objectAtIndex:0]];
+				if ([_cellsInViewHierarchy count])
+					[self enqueueCell:[_cellsInViewHierarchy objectAtIndex:0]];
 			}
 		}
 		
-		if(NSMaxRange(visibleRange) > NSMaxRange(_currentRange)) // Add bottom.
+		if(NSMaxRange(extendedRange) > NSMaxRange(_currentRange)) // Add bottom.
 		{
-			for(NSUInteger i = NSMaxRange(_currentRange); i < NSMaxRange(visibleRange); i++)
+			for(NSUInteger i = NSMaxRange(_currentRange); i < NSMaxRange(extendedRange); i++)
 			{
 				NSInteger newRow = i;
 				PXListViewCell *cell = [[self delegate] listView:self cellForRow: newRow];
                 
-				[_visibleCells addObject:cell];
+				[_cellsInViewHierarchy addObject:cell];
 				[self layoutCell:cell atRow:newRow];
 			}
 		}
 		
-        if(NSMaxRange(visibleRange) < NSMaxRange(_currentRange)) // Remove bottom.
+        if(NSMaxRange(extendedRange) < NSMaxRange(_currentRange)) // Remove bottom.
 		{
-			for(NSUInteger i = NSMaxRange(_currentRange); i > NSMaxRange(visibleRange); i--)
+			for(NSUInteger i = NSMaxRange(_currentRange); i > NSMaxRange(extendedRange); i--)
 			{
-				[self enqueueCell:[_visibleCells lastObject]];
+				[self enqueueCell:[_cellsInViewHierarchy lastObject]];
 			}
 		}
 	}
 	
-	_currentRange = visibleRange;
+	_currentRange = extendedRange;
 }
 
 #pragma mark -
@@ -513,7 +575,7 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 - (void)layoutCells
 {	
 	//Set the frames of the cells
-	for(id cell in _visibleCells)
+	for(id cell in _cellsInViewHierarchy)
 	{
 		NSInteger row = [cell row];
 		[cell setFrame:[self rectOfRow:row]];
@@ -545,13 +607,13 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 	
 	if(![self inLiveResize]||[self usesLiveResize])
 	{
-		[_visibleCells removeAllObjects];
+		[_cellsInViewHierarchy removeAllObjects];
 		[[self documentView] setSubviews:[NSArray array]];
 		
 		[self cacheCellLayout];
-		[self addCellsFromVisibleRange];
+		[self addCellsFromExtendedRange];
 		
-		_currentRange = [self visibleRange];
+		_currentRange = [self extendedRange];
 	}
     else if([self inLiveResize]&&![self usesLiveResize]) {
         [self updateCells];
@@ -626,11 +688,11 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 -(void)layoutCellsForResizeEvent 
 {
     //Change the layout of the cells
-    [_visibleCells removeAllObjects];
+    [_cellsInViewHierarchy removeAllObjects];
     [[self documentView] setSubviews:[NSArray array]];
     
     [self cacheCellLayout];
-    [self addCellsFromVisibleRange];
+    [self addCellsFromExtendedRange];
     
     if ([_delegate conformsToProtocol:@protocol(PXListViewDelegate)])
     {
@@ -650,7 +712,7 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
         [[self documentView] setFrame:NSMakeRect(0.0f, 0.0f, NSWidth([self contentViewRect]), documentHeight)];
     }
     
-    _currentRange = [self visibleRange];
+    _currentRange = [self extendedRange];
 }
 
 -(void)viewDidEndLiveResize
@@ -714,7 +776,7 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 				|| [attribute isEqualToString: NSAccessibilityContentsAttribute]
 				|| [attribute isEqualToString: NSAccessibilityChildrenAttribute] )
 	{
-		return _visibleCells;
+		return _cellsInViewHierarchy;
 	}
 	else if( [attribute isEqualToString: NSAccessibilitySelectedChildrenAttribute] )
 	{

--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ You can also load cells from NIBs easily, by using `PXListViewCell`'s class meth
 `PXListView` has a property, `usesLiveResize` which determines whether the control should be updated continuously during a resize or not. By default, the cells will be updated continuously as the control is resized. Although visually preferable, especially when dealing with large data sets, this can cause the UI to become slow, so this can be turned off by setting the property to `NO`.
 
 ###Optimizations###
-`PXListView` only keeps the bare minimum of list view cells in the view hierarchy to be performant, and when rows are scrolled onscreen new cells are added to the view hierarchy to display the rows, and when the rows are scrolled offscreen the associated cells are removed from the view hierarchy.
+`PXListView` only keeps in a view hierarchy the minimum of list view cells needed to be performant. When rows are scrolled, new cells are added to the view hierarchy, and a while after rows are scrolled offscreen, the associated cells are removed from the view hierarchy.
 
 Attributions
 ------------


### PR DESCRIPTION
Reverse and push further the idea of offscreen preparation as done in commit f30312bbe553a243e8be99fa5cfaba91f381ff44.
We add and remove cells in a view hierarchy which from now has a height of three times the height of the visible rectangle; so we are able to quickly respond to `pageDown` and `pageUp` requests.
Fix https://github.com/ViennaRSS/vienna-rss/issues/229 ; should probably fix issue #20 too.
