### PR TITLE
Prevent a memory leak

### DIFF
--- a/Classes/PXListView.m
+++ b/Classes/PXListView.m
@@ -36,7 +36,6 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 		_selectedRows = [[NSMutableIndexSet alloc] init];
 		_allowsEmptySelection = YES;
         _usesLiveResize = YES;
-        _cellYOffsets = NULL;
 	}
 	
 	return self;
@@ -51,7 +50,6 @@ NSString * const PXListViewSelectionDidChange = @"PXListViewSelectionDidChange";
 		_selectedRows = [[NSMutableIndexSet alloc] init];
 		_allowsEmptySelection = YES;
         _usesLiveResize = YES;
-        _cellYOffsets = NULL;
 	}
 	
 	return self;


### PR DESCRIPTION
Successive calls to -cacheCellLayout could lead to memory being allocated without being freed.
